### PR TITLE
Copy application files into Docker image and run server on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN pip install imageio imageio-ffmpeg==0.4.4
 RUN pip install click scipy 
 
 WORKDIR /workspace
+COPY . .
 
 ENTRYPOINT []
-CMD ["/bin/bash"]
+CMD ["python3", "stylegan_server.py"]
 


### PR DESCRIPTION
## Summary
- Copy repository contents into container image during build
- Set container default command to launch `stylegan_server.py`

## Testing
- `docker --version` *(fails: command not found)*
- `python -m py_compile stylegan_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b64f60922c8325a4ee8f8fbc219fa7