### PR TITLE
Add basic web interface for image streaming

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>StyleGAN Image Stream</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; }
+        img { max-width: 512px; width: 100%; height: auto; display: block; margin: 1rem auto; }
+        button { margin: 0.5rem; padding: 0.5rem 1rem; font-size: 1rem; }
+    </style>
+</head>
+<body>
+    <h1>StyleGAN Image Stream</h1>
+    <div>
+        <button id="start">Start</button>
+        <button id="stop">Stop</button>
+    </div>
+    <img id="image" alt="Generated image" />
+
+    <script>
+        let running = false;
+
+        async function fetchLoop() {
+            if (!running) return;
+            try {
+                const response = await fetch('/next', { cache: 'no-cache' });
+                const blob = await response.blob();
+                document.getElementById('image').src = URL.createObjectURL(blob);
+            } catch (err) {
+                console.error('Error fetching image:', err);
+                running = false;
+                return;
+            }
+            if (running) {
+                requestAnimationFrame(fetchLoop);
+            }
+        }
+
+        document.getElementById('start').addEventListener('click', async () => {
+            await fetch('/start', { method: 'POST' });
+            running = true;
+            fetchLoop();
+        });
+
+        document.getElementById('stop').addEventListener('click', () => {
+            running = false;
+        });
+    </script>
+</body>
+</html>

--- a/stylegan_server.py
+++ b/stylegan_server.py
@@ -55,6 +55,12 @@ noise_gen = NoiseGenerator(ns=base_generator.z_dim, steps=60)
 last_vector = None
 
 
+@app.route("/")
+def index_page():
+    """Serve the client-side interface."""
+    return send_file(os.path.join(os.path.dirname(__file__), "index.html"))
+
+
 @app.route("/start", methods=["POST"])
 def start_walk():
     """Start a new interpolation sequence."""


### PR DESCRIPTION
## Summary
- Add `index.html` with start/stop buttons and JavaScript loop to display images from `/next`
- Serve the new index page via a root route in `stylegan_server.py`

## Testing
- `python -m py_compile stylegan_server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b65b2c058483258f97f7fd0ec68dc8