### PR TITLE
Display model and noise debug info on index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>StyleGAN Image Stream</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; }
+        img { max-width: 512px; width: 100%; height: auto; display: block; margin: 1rem auto; }
+        button { margin: 0.5rem; padding: 0.5rem 1rem; font-size: 1rem; }
+    </style>
+</head>
+<body>
+    <h1>StyleGAN Image Stream</h1>
+    <div>
+        <button id="start">Start</button>
+        <button id="stop">Stop</button>
+    </div>
+    <img id="image" alt="Generated image" />
+
+    <div id="debug">
+        <h2>Debug Info</h2>
+        <ul>
+            <li><strong>Model Name:</strong> {{ model_name }}</li>
+            <li><strong>Image Size:</strong> {{ image_size }}</li>
+            <li><strong>Model Parameters:</strong> {{ model_params }}</li>
+            <li><strong>Model Mode:</strong> {{ model_mode }}</li>
+            <li><strong>Device:</strong> {{ device }}</li>
+            <li><strong>Precision:</strong> {{ precision }}</li>
+            <li><strong>Noise Size:</strong> {{ noise_size }}</li>
+            <li><strong>Noise Step:</strong> {{ noise_step }} / {{ noise_total_steps }}</li>
+        </ul>
+    </div>
+
+    <script>
+        let running = false;
+
+        async function fetchLoop() {
+            if (!running) return;
+            try {
+                const response = await fetch('/next', { cache: 'no-cache' });
+                const blob = await response.blob();
+                document.getElementById('image').src = URL.createObjectURL(blob);
+            } catch (err) {
+                console.error('Error fetching image:', err);
+                running = false;
+                return;
+            }
+            if (running) {
+                requestAnimationFrame(fetchLoop);
+            }
+        }
+
+        document.getElementById('start').addEventListener('click', async () => {
+            await fetch('/start', { method: 'POST' });
+            running = true;
+            fetchLoop();
+        });
+
+        document.getElementById('stop').addEventListener('click', () => {
+            running = false;
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Show debug information about the loaded model and noise generator on the index page
- Precompute and pass model metadata and noise stats from server runtime to the template

## Testing
- `python -m py_compile stylegan_server.py stylegan_gen.py`


------
https://chatgpt.com/codex/tasks/task_b_68b65e2253588325a7973551b5ff32b8