### PR TITLE
Separate walk and image storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,14 @@ python stylegan_server.py
 Generate images by performing a latent walk:
 
 ```bash
-# start a new interpolation sequence
-curl -X POST http://localhost:5000/start
+# define a random walk and load it
+curl -X POST http://localhost:5000/start_random_walk
 
-# fetch the next image (PNG binary response)
-curl -o frame.png http://localhost:5000/next
-
-# retrieve the latent vector used for the last image
-curl http://localhost:5000/vector
+# fetch the next image in the walk (PNG binary response)
+curl -o frame.png http://localhost:5000/next_image
 ```
 
-Repeated calls to `/next` continue the interpolation. Restart the sequence by
-calling `/start` again.
+Visit `http://localhost:5000/gallery` to browse saved walks and images. The
+gallery interface also allows creating curated walks by interpolating between
+selected keyframes.
 

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-g">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ title }}</title>
+    <title>Walk Gallery</title>
     <style>
         body { font-family: sans-serif; background-color: #f0f2f5; margin: 0; padding: 20px; }
-        h1, p { text-align: center; }
+        h1, h2, p { text-align: center; }
         a { color: #007bff; }
         .controls { text-align: center; margin-bottom: 20px; padding: 15px; background: #fff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .walk { margin-bottom: 40px; }
         .gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 15px; }
         .img-container { position: relative; cursor: pointer; }
         .img-container img { width: 100%; height: auto; display: block; border-radius: 8px; transition: transform 0.2s; }
@@ -31,66 +32,65 @@
     </style>
 </head>
 <body>
-
-    <h1>Image Gallery</h1>
-    <p>Select images in the order you want to create the animation path. <a href="/">Back to Generator</a></p>
+    <h1>Walk Gallery</h1>
+    <p>Select images in the order you want to create a new walk. <a href="/">Back to Generator</a></p>
 
     <div class="controls">
         <button id="createWalkBtn">Create Custom Walk From Selection</button>
         <p id="status"></p>
     </div>
 
-    <div class="gallery">
-        {% for image_file in images %}
-        <label class="img-container">
-            <input type="checkbox" name="image_selection" value="{{ image_file }}">
-            <img src="{{ url_for('serve_generated_image', filename=image_file) }}" alt="{{ image_file }}" loading="lazy">
-            <div class="selection-order"></div>
-        </label>
-        {% endfor %}
+    {% for walk in walks %}
+    <div class="walk">
+        <h2>Walk {{ walk[0] }}: {{ walk[1] }} ({{ walk[2] }})</h2>
+        <div class="gallery">
+            {% for image in images_by_walk.get(walk[0], []) %}
+            <label class="img-container">
+                <input type="checkbox" name="image_selection" value="{{ image.id }}">
+                <img src="{{ url_for('serve_generated_image', filename=image.filename) }}" alt="{{ image.filename }}" loading="lazy">
+                <div class="selection-order"></div>
+            </label>
+            {% endfor %}
+        </div>
     </div>
+    {% endfor %}
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const createWalkBtn = document.getElementById('createWalkBtn');
             const statusEl = document.getElementById('status');
-            const gallery = document.querySelector('.gallery');
-            let selectedFiles = [];
+            let selectedIds = [];
 
-            gallery.addEventListener('change', (event) => {
-                if (event.target.type === 'checkbox') {
-                    const filename = event.target.value;
-                    const container = event.target.closest('.img-container');
-                    const orderBadge = container.querySelector('.selection-order');
+            document.querySelectorAll('.gallery').forEach(gallery => {
+                gallery.addEventListener('change', (event) => {
+                    if (event.target.type === 'checkbox') {
+                        const id = event.target.value;
+                        const container = event.target.closest('.img-container');
+                        const orderBadge = container.querySelector('.selection-order');
 
-                    if (event.target.checked) {
-                        selectedFiles.push(filename);
-                        orderBadge.textContent = selectedFiles.length;
-                    } else {
-                        const index = selectedFiles.indexOf(filename);
-                        if (index > -1) {
-                            selectedFiles.splice(index, 1);
+                        if (event.target.checked) {
+                            selectedIds.push(id);
+                            orderBadge.textContent = selectedIds.length;
+                        } else {
+                            const index = selectedIds.indexOf(id);
+                            if (index > -1) selectedIds.splice(index, 1);
+                            updateBadges();
                         }
-                        updateBadges();
                     }
-                }
+                });
             });
 
             function updateBadges() {
                 document.querySelectorAll('.img-container input').forEach(checkbox => {
-                    const filename = checkbox.value;
+                    const id = checkbox.value;
                     const orderBadge = checkbox.closest('.img-container').querySelector('.selection-order');
-                    const index = selectedFiles.indexOf(filename);
-                    if (index > -1) {
-                        orderBadge.textContent = index + 1;
-                    } else {
-                        orderBadge.textContent = '';
-                    }
+                    const index = selectedIds.indexOf(id);
+                    orderBadge.textContent = index > -1 ? index + 1 : '';
                 });
             }
 
             createWalkBtn.addEventListener('click', () => {
-                if (selectedFiles.length < 2) {
+                if (selectedIds.length < 2) {
                     alert('Please select at least two images to create a walk.');
                     return;
                 }
@@ -99,18 +99,13 @@
 
                 fetch('/create_custom_walk', {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                        filenames: selectedFiles,
-                        steps: 60
-                    }),
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ids: selectedIds, steps: 60 })
                 })
                 .then(response => response.json())
                 .then(data => {
                     if (data.status === 'success') {
-                        statusEl.textContent = `Success! New walk with ${data.total_steps} steps created.`;
+                        statusEl.textContent = `Success! New walk with ID ${data.walk_id} created.`;
                         alert('Custom walk created! You will now be redirected to the main page.');
                         window.location.href = '/';
                     } else {
@@ -125,6 +120,5 @@
             });
         });
     </script>
-
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <title>StyleGAN Image Stream</title>
+    <title>StyleGAN Walk</title>
     <style>
         body { font-family: Arial, sans-serif; text-align: center; }
         img { max-width: 512px; width: 100%; height: auto; display: block; margin: 1rem auto; }
@@ -10,49 +10,35 @@
     </style>
 </head>
 <body>
-    <h1>StyleGAN Image Stream</h1>
+    <h1>StyleGAN Walk</h1>
     <div>
-        <button id="start">Start</button>
+        <button id="start">Start Random Walk</button>
         <button id="stop">Stop</button>
         <a href="/gallery">Gallery</a>
     </div>
     <img id="image" alt="Generated image" />
-
-    <div id="debug">
-        <h2>Debug Info</h2>
-        <ul>
-            <li><strong>Model Name:</strong> {{ model_name }}</li>
-            <li><strong>Image Size:</strong> {{ image_size }}</li>
-            <li><strong>Model Parameters:</strong> {{ model_params }}</li>
-            <li><strong>Model Mode:</strong> {{ model_mode }}</li>
-            <li><strong>Device:</strong> {{ device }}</li>
-            <li><strong>Precision:</strong> {{ precision }}</li>
-            <li><strong>Noise Size:</strong> {{ noise_size }}</li>
-            <li><strong>Noise Step:</strong> {{ noise_step }} / {{ noise_total_steps }}</li>
-        </ul>
-    </div>
-
     <script>
         let running = false;
 
         async function fetchLoop() {
             if (!running) return;
             try {
-                const response = await fetch('/next', { cache: 'no-cache' });
+                const response = await fetch('/next_image', { cache: 'no-cache' });
+                if (!response.ok) {
+                    running = false;
+                    return;
+                }
                 const blob = await response.blob();
                 document.getElementById('image').src = URL.createObjectURL(blob);
+                requestAnimationFrame(fetchLoop);
             } catch (err) {
                 console.error('Error fetching image:', err);
                 running = false;
-                return;
-            }
-            if (running) {
-                requestAnimationFrame(fetchLoop);
             }
         }
 
         document.getElementById('start').addEventListener('click', async () => {
-            await fetch('/start', { method: 'POST' });
+            await fetch('/start_random_walk', { method: 'POST' });
             running = true;
             fetchLoop();
         });


### PR DESCRIPTION
## Summary
- Split database into `walks` and `generated_images` tables to store definitions separately from rendered steps
- Add walk management routes (`start_random_walk`, `load_walk`, `next_image`, and `create_custom_walk`)
- Refresh HTML templates for new API and curated walk creation

## Testing
- `python -m py_compile stylegan_server.py`
- `python stylegan_server.py --help` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(failed: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_b_68b7794196d483258f2f719f953ff81a