### PR TITLE
refactor: add latent interpolation helper

### DIFF
--- a/stylegan_gen.py
+++ b/stylegan_gen.py
@@ -5,6 +5,8 @@ import torch
 import legacy
 import dnnlib
 
+from utils import LatentInterpolator
+
 class StyleGANGenerator:
     """
     A wrapper for a pre-trained StyleGAN3 generator network.
@@ -89,33 +91,6 @@ class StyleGANGenerator:
         # 3. Post-Processing
         img_tensor = (img_tensor.float().permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
         return PIL.Image.fromarray(img_tensor[0].cpu().numpy(), 'RGB')
-
-
-class LatentInterpolator:
-    """
-    A helper to create smooth interpolations between latent vectors.
-    """
-    def __init__(self, z_dim: int, n_steps: int = 60):
-        self.z_dim = z_dim
-        self.n_steps = n_steps
-
-    def interpolate(self, z1: np.ndarray, z2: np.ndarray) -> np.ndarray:
-        """
-        Creates a linear interpolation between two latent vectors.
-
-        Args:
-            z1 (np.ndarray): The starting latent vector, shape [z_dim].
-            z2 (np.ndarray): The ending latent vector, shape [z_dim].
-
-        Returns:
-            np.ndarray: An array of interpolated latent vectors, shape [n_steps, z_dim].
-        """
-        ratios = np.linspace(0, 1, num=self.n_steps)
-        vectors = []
-        for ratio in ratios:
-            v = (1.0 - ratio) * z1 + ratio * z2
-            vectors.append(v)
-        return np.asarray(vectors)
 
 
 # ==============================================================================

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for StyleGAN server."""
+
+from .interpolation import LatentInterpolator
+
+__all__ = ["LatentInterpolator"]

--- a/utils/interpolation.py
+++ b/utils/interpolation.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+class LatentInterpolator:
+    """Helper class to create smooth interpolations in latent space."""
+
+    def __init__(self, z_dim: int, n_steps: int = 60):
+        self.z_dim = z_dim
+        self.n_steps = n_steps
+
+    def interpolate(self, z1: np.ndarray, z2: np.ndarray) -> np.ndarray:
+        """Linearly interpolate between two latent vectors."""
+        ratios = np.linspace(0, 1, num=self.n_steps, dtype=np.float32)
+        return np.array([(1.0 - r) * z1 + r * z2 for r in ratios], dtype=np.float32)
+
+    def random_walk(self, num_segments: int = 1, start: np.ndarray | None = None, seed: int | None = None) -> np.ndarray:
+        """
+        Generate a random walk through latent space composed of multiple segments.
+
+        Args:
+            num_segments: Number of random interpolation segments to chain together.
+            start: Optional starting latent vector. If None, a random vector is used.
+            seed: Optional RNG seed for reproducibility.
+
+        Returns:
+            np.ndarray: Array of latent vectors forming the random walk with shape
+                [num_segments * n_steps, z_dim].
+        """
+        rng = np.random.default_rng(seed)
+        current = rng.standard_normal(self.z_dim) if start is None else np.asarray(start, dtype=np.float32)
+        walk = []
+        for _ in range(num_segments):
+            next_vec = rng.standard_normal(self.z_dim)
+            segment = self.interpolate(current, next_vec)
+            if walk:
+                segment = segment[1:]  # Avoid duplicating boundary between segments
+            walk.append(segment)
+            current = next_vec
+        return np.vstack(walk)


### PR DESCRIPTION
## Summary
- extract `LatentInterpolator` to `utils` and add multi-segment random walk helper
- reuse interpolation helper in `stylegan_server.start_random_walk`
- update generator module to import the shared helper

## Testing
- `python -m py_compile utils/interpolation.py stylegan_gen.py stylegan_server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7830735508325929a630036ba1022