### PR TITLE
Auto-play custom walks via query flag

### DIFF
--- a/stylegan_server.py
+++ b/stylegan_server.py
@@ -140,6 +140,7 @@ def get_vector_by_image_id(image_id):
 # ----------------------------------------------------------------------------
 
 @app.route("/")
+@app.route("/index")
 def index_page():
     """Serve the client-side interface."""
     return render_template("index.html", title="Home")

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -107,7 +107,7 @@
                     if (data.status === 'success') {
                         statusEl.textContent = `Success! New walk with ID ${data.walk_id} created.`;
                         alert('Custom walk created! You will now be redirected to the main page.');
-                        window.location.href = '/';
+                        window.location.href = '/index?autoplay=true';
                     } else {
                         throw new Error(data.message);
                     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,8 @@
 <body>
     <h1>StyleGAN Walk</h1>
     <div>
-        <button id="start">Start Random Walk</button>
+        <button id="play">Play</button>
+        <button id="startRandom">Start Random Walk</button>
         <button id="stop">Stop</button>
         <a href="/gallery">Gallery</a>
     </div>
@@ -37,7 +38,12 @@
             }
         }
 
-        document.getElementById('start').addEventListener('click', async () => {
+        document.getElementById('play').addEventListener('click', () => {
+            running = true;
+            fetchLoop();
+        });
+
+        document.getElementById('startRandom').addEventListener('click', async () => {
             await fetch('/start_random_walk', { method: 'POST' });
             running = true;
             fetchLoop();
@@ -46,6 +52,12 @@
         document.getElementById('stop').addEventListener('click', () => {
             running = false;
         });
+
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('autoplay') === 'true') {
+            running = true;
+            fetchLoop();
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Allow hitting `/index` as an alias to `/`
- Auto-play custom walks when redirected with `?autoplay=true`
- Add dedicated "Start Random Walk" button and play control

## Testing
- `python -m py_compile stylegan_server.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_b_68b78a6fee7483259c283f285c5c6c76