### PR TITLE
Organize generated images in instance subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,17 @@ Visit `http://localhost:5000/gallery` to browse saved walks and images. The
 gallery interface also allows creating curated walks by interpolating between
 selected keyframes.
 
+## Output Directory Structure
+
+Generated images are now stored in a nested layout under the configured
+`outdir`:
+
+```
+<outdir>/<instance_id>/<rand8>/<filename>
+```
+
+`instance_id` identifies the running server instance (it can be overridden via
+the `INSTANCE_ID` environment variable) and `rand8` is a random eight-digit
+folder created for each rendered image. The relative path is stored in the
+database and used by the gallery when serving images.
+

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -47,7 +47,7 @@
             {% for image in images_by_walk.get(walk[0], []) %}
             <label class="img-container">
                 <input type="checkbox" name="image_selection" value="{{ image.id }}">
-                <img src="{{ url_for('serve_generated_image', filename=image.filename) }}" alt="{{ image.filename }}" loading="lazy">
+                <img src="{{ url_for('serve_generated_image', instance_id=image.instance_id, rand8=image.rand8, filename=image.filename) }}" alt="{{ image.filename }}" loading="lazy">
                 <div class="selection-order"></div>
             </label>
             {% endfor %}


### PR DESCRIPTION
## Summary
- Save each rendered frame under `<outdir>/<instance_id>/<rand8>/<filename>` and track the relative path in the database
- Serve gallery images from their new nested paths via updated template and Flask route
- Document the new output directory structure and instance handling in the README

## Testing
- `python -m py_compile stylegan_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7927f8c48832591a1e0523ad7d32d