### PR TITLE
Add walk deletion to gallery page

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -29,6 +29,8 @@
         }
         #createWalkBtn { padding: 10px 20px; font-size: 16px; cursor: pointer; border-radius: 5px; border: none; background-color: #28a745; color: white; }
         #createWalkBtn:hover { background-color: #218838; }
+        .delete-walk { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #dc3545; color: white; }
+        .delete-walk:hover { background-color: #c82333; }
     </style>
 </head>
 <body>
@@ -42,7 +44,7 @@
 
     {% for walk in walks %}
     <div class="walk">
-        <h2>Walk {{ walk[0] }}: {{ walk[1] }} ({{ walk[2] }})</h2>
+        <h2>Walk {{ walk[0] }}: {{ walk[1] }} ({{ walk[2] }}) <button class="delete-walk" data-walk-id="{{ walk[0] }}">Delete</button></h2>
         <div class="gallery">
             {% for image in images_by_walk.get(walk[0], []) %}
             <label class="img-container">
@@ -116,6 +118,28 @@
                     console.error('Error:', error);
                     statusEl.textContent = `Error: ${error.message}`;
                     alert(`Error: ${error.message}`);
+                });
+            });
+
+            document.querySelectorAll('.delete-walk').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const walkId = btn.getAttribute('data-walk-id');
+                    if (!confirm(`Delete walk ${walkId}?`)) return;
+
+                    fetch(`/delete_walk/${walkId}`, { method: 'DELETE' })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.status === 'success') {
+                            alert(`Walk ${walkId} deleted.`);
+                            window.location.reload();
+                        } else {
+                            throw new Error(data.message || 'Failed to delete walk');
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert(`Error: ${error.message}`);
+                    });
                 });
             });
         });


### PR DESCRIPTION
## Summary
- allow deleting a walk and its rendered images via new `/delete_walk` endpoint
- add Delete buttons on gallery entries with JS to call backend

## Testing
- `python -m py_compile stylegan_server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b7946aab988325b3521d7ecd51b402