### PR TITLE
Display walk progress with next image

### DIFF
--- a/stylegan_server.py
+++ b/stylegan_server.py
@@ -1,11 +1,12 @@
 import os
 from io import BytesIO
+import base64
 import argparse
 import numpy as np
 import sqlite3
 import uuid
 import random
-from flask import Flask, send_file, jsonify, render_template, request, send_from_directory
+from flask import Flask, jsonify, render_template, request, send_from_directory
 
 from stylegan_gen import StyleGANGenerator
 from utils import LatentInterpolator
@@ -245,7 +246,16 @@ def get_next_image():
     buf = BytesIO()
     img.save(buf, format="PNG")
     buf.seek(0)
-    return send_file(buf, mimetype="image/png")
+    img_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+    return jsonify(
+        {
+            "image": img_b64,
+            "walk_id": current_walk["walk_id"],
+            "step": step,
+            "total_steps": len(current_walk["vectors"]),
+        }
+    )
 
 
 # --- Gallery and Custom Walk Creation Routes (Adapted for new schema) ---

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
         body { font-family: Arial, sans-serif; text-align: center; }
         img { max-width: 512px; width: 100%; height: auto; display: block; margin: 1rem auto; }
         button { margin: 0.5rem; padding: 0.5rem 1rem; font-size: 1rem; }
+        #stats { margin-top: 1rem; }
     </style>
 </head>
 <body>
@@ -18,6 +19,7 @@
         <a href="/gallery">Gallery</a>
     </div>
     <img id="image" alt="Generated image" />
+    <div id="stats"></div>
     <script>
         let running = false;
 
@@ -27,10 +29,13 @@
                 const response = await fetch('/next_image', { cache: 'no-cache' });
                 if (!response.ok) {
                     running = false;
+                    const err = await response.json().catch(() => ({}));
+                    document.getElementById('stats').textContent = err.status || err.error || 'Error';
                     return;
                 }
-                const blob = await response.blob();
-                document.getElementById('image').src = URL.createObjectURL(blob);
+                const data = await response.json();
+                document.getElementById('image').src = `data:image/png;base64,${data.image}`;
+                document.getElementById('stats').textContent = `Walk ${data.walk_id}: step ${data.step + 1} / ${data.total_steps}`;
                 requestAnimationFrame(fetchLoop);
             } catch (err) {
                 console.error('Error fetching image:', err);


### PR DESCRIPTION
## Summary
- Return base64 image and progress stats from `/next_image` route
- Show walk statistics on the generator page alongside each image

## Testing
- `python -m py_compile stylegan_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b796f83b5c8325ac0106cb3a286a4d