### PR TITLE
Remove random output folders for saved walk images

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,14 @@ selected keyframes.
 
 ## Output Directory Structure
 
-Generated images are now stored in a nested layout under the configured
-`outdir`:
+Generated images are stored in a layout where each walk has its own folder:
 
 ```
-<outdir>/<instance_id>/<rand8>/<filename>
+<outdir>/<walk_id>/<filename>
 ```
 
-`instance_id` identifies the running server instance (it can be overridden via
-the `INSTANCE_ID` environment variable) and `rand8` is a random eight-digit
-folder created for each rendered image. The relative path is stored in the
-database and used by the gallery when serving images.
+`walk_id` is the identifier of the walk in the database. Filenames only need to
+be unique within a given walk, allowing the same names to appear in different
+walk folders. The relative path is stored in the database and used by the
+gallery when serving images.
 

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -55,9 +55,9 @@
             <h2>Walk {{ walk[0] }}: {{ walk[1] }} ({{ walk[2] }}, step rate {{ walk[4] }}) <button class="delete-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Delete</button></h2>
             <div class="thumbs">
                 {% if images %}
-                <img src="{{ url_for('serve_generated_image', instance_id=images[0].instance_id, rand8=images[0].rand8, filename=images[0].filename) }}" alt="start image">
+                <img src="{{ url_for('serve_generated_image', walk_id=walk[0], filename=images[0].filename) }}" alt="start image">
                 {% if images|length > 1 %}
-                <img src="{{ url_for('serve_generated_image', instance_id=images[-1].instance_id, rand8=images[-1].rand8, filename=images[-1].filename) }}" alt="end image">
+                <img src="{{ url_for('serve_generated_image', walk_id=walk[0], filename=images[-1].filename) }}" alt="end image">
                 {% endif %}
                 {% endif %}
             </div>
@@ -66,7 +66,7 @@
             {% for image in images %}
             <label class="img-container">
                 <input type="checkbox" name="image_selection" value="{{ image.id }}">
-                <img src="{{ url_for('serve_generated_image', instance_id=image.instance_id, rand8=image.rand8, filename=image.filename) }}" alt="{{ image.filename }}" loading="lazy">
+                <img src="{{ url_for('serve_generated_image', walk_id=walk[0], filename=image.filename) }}" alt="{{ image.filename }}" loading="lazy">
                 <div class="selection-order"></div>
             </label>
             {% endfor %}


### PR DESCRIPTION
## Summary
- Save generated images under `<walk_id>` folders instead of per-instance and random directories
- Adjust gallery and image-serving routes to new `<walk_id>/<filename>` layout
- Update README to describe simplified output structure

## Testing
- `python -m py_compile stylegan_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68b7aab0489083258c3183c5ee703986